### PR TITLE
Add shortcuts

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -26,6 +26,8 @@
 		"prosemirror",
 		"unsub",
 		"steeze",
-		"tauri"
+		"tauri",
+		"Internationalizator",
+		"keymap"
 	]
 }

--- a/cspell.json
+++ b/cspell.json
@@ -29,6 +29,7 @@
 		"tauri",
 		"Internationalizator",
 		"keymap",
-		"onfocusincapture"
+		"onfocusincapture",
+		"inlang"
 	]
 }

--- a/cspell.json
+++ b/cspell.json
@@ -30,6 +30,10 @@
 		"Internationalizator",
 		"keymap",
 		"onfocusincapture",
-		"inlang"
+		"inlang",
+		"arrowup",
+		"arrowdown",
+		"arrowleft",
+		"arrowright"
 	]
 }

--- a/cspell.json
+++ b/cspell.json
@@ -28,6 +28,7 @@
 		"steeze",
 		"tauri",
 		"Internationalizator",
-		"keymap"
+		"keymap",
+		"onfocusincapture"
 	]
 }

--- a/cspell.json
+++ b/cspell.json
@@ -25,6 +25,7 @@
 		"onrelocate",
 		"prosemirror",
 		"unsub",
-		"steeze"
+		"steeze",
+		"tauri"
 	]
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "identifier": "com.writers-ide.app",
   "build": {
-    "beforeDevCommand": "pnpm dev:tauri",
+    "beforeDevCommand": "pnpm dev",
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "pnpm build",
     "frontendDist": "../build"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "identifier": "com.writers-ide.app",
   "build": {
-    "beforeDevCommand": "pnpm dev:vite",
+    "beforeDevCommand": "pnpm dev:tauri",
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "pnpm build",
     "frontendDist": "../build"

--- a/src/lib/editor/bars/BarLocation.svelte
+++ b/src/lib/editor/bars/BarLocation.svelte
@@ -8,15 +8,18 @@
 </script>
 
 <script lang="ts">
+	import { Icon } from '@steeze-ui/svelte-icon';
+	import { DotsThree } from '@steeze-ui/phosphor-icons';
+
 	import * as m from '$lib/paraglide/messages';
 
 	import type { BarTransferLocation } from '../state/bar-transfer-handler.svelte';
 	import { HorizontalBarPosition } from '../state/horizontal-bar-state.svelte';
 	import { VerticalBarPosition } from '../state/vertical-bar-state.svelte';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
-	import { Icon } from '@steeze-ui/svelte-icon';
-	import { DotsThree } from '@steeze-ui/phosphor-icons';
 	import TransferHandler from '../state/bar-transfer-handler.svelte';
+	import { onMount } from 'svelte';
+	import Shortcuts from '../state/shortcuts.svelte';
 
 	let {
 		onrelocate,
@@ -30,6 +33,8 @@
 		position: BarTransferLocation;
 	} = $props();
 
+	let open = $state(false);
+
 	function handleRelocate(val: string | undefined) {
 		if (!val) {
 			return;
@@ -37,13 +42,27 @@
 
 		if (TransferHandler.isBarLocation(val)) {
 			onrelocate(val);
-		} else {
-			console.error('Invalid bar location:', val);
 		}
 	}
+
+	onMount(() => {
+		// TODO: Figure out to determine if what bar the keydown is relevant to - maybe track last interacted bar?
+		const unsub = Shortcuts.on({
+			'move-bar-up': () => open && onmove('up'),
+			'move-bar-down': () => open && onmove('down'),
+			'move-bar-left': () => open && onmove('left'),
+			'move-bar-right': () => open && onmove('right'),
+			'move-bar-inline-start': () => open && onrelocate(VerticalBarPosition.InlineStart),
+			'move-bar-inline-end': () => open && onrelocate(VerticalBarPosition.InlineEnd),
+			'move-bar-block-start': () => open && onrelocate(HorizontalBarPosition.WindowBlockStart),
+			'move-bar-block-end': () => open && onrelocate(HorizontalBarPosition.WindowBlockEnd),
+			'move-bar-floating': () => open && onrelocate('floating')
+		});
+		return unsub;
+	});
 </script>
 
-<DropdownMenu.Root>
+<DropdownMenu.Root bind:open>
 	<DropdownMenu.Trigger aria-label={m.position_item()}>
 		<Icon src={DotsThree} size="16px" />
 	</DropdownMenu.Trigger>
@@ -53,45 +72,67 @@
 		<DropdownMenu.RadioGroup value={position} onValueChange={(e) => handleRelocate(e)}>
 			<DropdownMenu.RadioItem value={HorizontalBarPosition.WindowBlockStart}>
 				<span>{m.window_block_start()}</span>
-				<DropdownMenu.Shortcut>⇧⌘P</DropdownMenu.Shortcut>
+				<DropdownMenu.Shortcut>
+					{Shortcuts.commandsToDisplayedShortcuts['move-bar-block-start']}
+				</DropdownMenu.Shortcut>
 			</DropdownMenu.RadioItem>
 			<DropdownMenu.RadioItem value={HorizontalBarPosition.WindowBlockEnd}>
 				<span>{m.window_block_end()}</span>
-				<DropdownMenu.Shortcut>⌘B</DropdownMenu.Shortcut>
+				<DropdownMenu.Shortcut>
+					{Shortcuts.commandsToDisplayedShortcuts['move-bar-block-end']}
+				</DropdownMenu.Shortcut>
 			</DropdownMenu.RadioItem>
 			<DropdownMenu.RadioItem value={VerticalBarPosition.InlineStart}>
 				<span>{m.window_inline_start()}</span>
-				<DropdownMenu.Shortcut>⌘S</DropdownMenu.Shortcut>
+				<DropdownMenu.Shortcut>
+					{Shortcuts.commandsToDisplayedShortcuts['move-bar-inline-start']}
+				</DropdownMenu.Shortcut>
 			</DropdownMenu.RadioItem>
 			<DropdownMenu.RadioItem value={VerticalBarPosition.InlineEnd}>
 				<span>{m.window_inline_end()}</span>
-				<DropdownMenu.Shortcut>⌘K</DropdownMenu.Shortcut>
+				<DropdownMenu.Shortcut>
+					{Shortcuts.commandsToDisplayedShortcuts['move-bar-inline-end']}
+				</DropdownMenu.Shortcut>
 			</DropdownMenu.RadioItem>
 			<DropdownMenu.RadioItem value="floating">
 				<span>{m.window_floating()}</span>
-				<DropdownMenu.Shortcut>⇧⌘F</DropdownMenu.Shortcut>
+				<DropdownMenu.Shortcut>
+					{Shortcuts.commandsToDisplayedShortcuts['move-bar-floating']}
+				</DropdownMenu.Shortcut>
 			</DropdownMenu.RadioItem>
 		</DropdownMenu.RadioGroup>
 		<DropdownMenu.Separator />
 		<DropdownMenu.Group>
 			{#if moveDetails.up !== null}
 				<DropdownMenu.Item disabled={!moveDetails.up} on:click={() => onmove('up')}>
-					{m.move_up()}
+					<span>{m.move_up()}</span>
+					<DropdownMenu.Shortcut>
+						{Shortcuts.commandsToDisplayedShortcuts['move-bar-up']}
+					</DropdownMenu.Shortcut>
 				</DropdownMenu.Item>
 			{/if}
 			{#if moveDetails.down !== null}
 				<DropdownMenu.Item disabled={!moveDetails.down} on:click={() => onmove('down')}>
-					{m.move_down()}
+					<span>{m.move_down()}</span>
+					<DropdownMenu.Shortcut>
+						{Shortcuts.commandsToDisplayedShortcuts['move-bar-down']}
+					</DropdownMenu.Shortcut>
 				</DropdownMenu.Item>
 			{/if}
 			{#if moveDetails.left !== null}
 				<DropdownMenu.Item disabled={!moveDetails.left} on:click={() => onmove('left')}>
-					{m.move_left()}
+					<span>{m.move_left()}</span>
+					<DropdownMenu.Shortcut>
+						{Shortcuts.commandsToDisplayedShortcuts['move-bar-left']}
+					</DropdownMenu.Shortcut>
 				</DropdownMenu.Item>
 			{/if}
 			{#if moveDetails.right !== null}
 				<DropdownMenu.Item disabled={!moveDetails.right} on:click={() => onmove('right')}>
-					{m.move_right()}
+					<span> {m.move_right()}</span>
+					<DropdownMenu.Shortcut>
+						{Shortcuts.commandsToDisplayedShortcuts['move-bar-right']}
+					</DropdownMenu.Shortcut>
 				</DropdownMenu.Item>
 			{/if}
 		</DropdownMenu.Group>

--- a/src/lib/editor/bars/VerticalBaseBar.svelte
+++ b/src/lib/editor/bars/VerticalBaseBar.svelte
@@ -4,6 +4,7 @@
 	} from '../state/bar-transfer-handler.svelte.js';
 	import { HorizontalBarPosition } from '../state/horizontal-bar-state.svelte.js';
 	import LocaleManager from '../state/locale-manager.svelte.js';
+	import Shortcuts from '../state/shortcuts.svelte.js';
 	import { VerticalBarPosition } from '../state/vertical-bar-state.svelte.js';
 
 	let selectValue: 'vertical' | 'horizontal' | 'floating' = 'vertical';
@@ -43,6 +44,9 @@
 			LocaleManager.data === 'en' ? (LocaleManager.data = 'fr') : (LocaleManager.data = 'en')}
 		>Change locale</button
 	>
+	<button onclick={() => Shortcuts.register('move-bar-up', 'meta-shift-arrowleft')}>
+		Change shortcut
+	</button>
 </div>
 
 <style>

--- a/src/lib/editor/prosemirror/plugins/shortcut.plugin.ts
+++ b/src/lib/editor/prosemirror/plugins/shortcut.plugin.ts
@@ -2,15 +2,24 @@ import Shortcuts from '@/editor/state/shortcuts.svelte';
 import { type Command, Plugin } from 'prosemirror-state';
 import type { EditorView } from 'prosemirror-view';
 
-export function keymap(commands: { [key: string]: Command }): Plugin {
-	return new Plugin({ props: { handleKeyDown: keydownHandler(commands) } });
+export function createShortcuts(bindings: { [key: string]: Command }): Plugin {
+	return new Plugin({ props: { handleKeyDown: keydownHandler(bindings) } });
 }
 
-export function keydownHandler(commands: {
+export function keydownHandler(bindings: {
 	[key: string]: Command;
 }): (view: EditorView, event: KeyboardEvent) => boolean {
-	return (_view, event) => {
+	return (view, event) => {
 		const command = Shortcuts.get(event);
-		return !!command && command in commands;
+		if (!command) {
+			return false;
+		}
+
+		const binding = bindings[command];
+		if (!binding) {
+			return false;
+		}
+
+		return binding(view.state, view.dispatch, view);
 	};
 }

--- a/src/lib/editor/prosemirror/plugins/shortcut.plugin.ts
+++ b/src/lib/editor/prosemirror/plugins/shortcut.plugin.ts
@@ -10,16 +10,21 @@ export function keydownHandler(bindings: {
 	[key: string]: Command;
 }): (view: EditorView, event: KeyboardEvent) => boolean {
 	return (view, event) => {
-		const command = Shortcuts.get(event);
-		if (!command) {
+		const commands = Shortcuts.get(event);
+		if (!commands) {
 			return false;
 		}
 
-		const binding = bindings[command];
-		if (!binding) {
-			return false;
+		let anyCommand = false;
+		for (const command of commands) {
+			const binding = bindings[command];
+			if (!anyCommand && typeof binding === 'function') {
+				anyCommand = true;
+			}
+
+			binding(view.state, view.dispatch, view);
 		}
 
-		return binding(view.state, view.dispatch, view);
+		return anyCommand;
 	};
 }

--- a/src/lib/editor/prosemirror/plugins/shortcut.plugin.ts
+++ b/src/lib/editor/prosemirror/plugins/shortcut.plugin.ts
@@ -1,0 +1,16 @@
+import Shortcuts from '@/editor/state/shortcuts.svelte';
+import { type Command, Plugin } from 'prosemirror-state';
+import type { EditorView } from 'prosemirror-view';
+
+export function keymap(commands: { [key: string]: Command }): Plugin {
+	return new Plugin({ props: { handleKeyDown: keydownHandler(commands) } });
+}
+
+export function keydownHandler(commands: {
+	[key: string]: Command;
+}): (view: EditorView, event: KeyboardEvent) => boolean {
+	return (_view, event) => {
+		const command = Shortcuts.get(event);
+		return !!command && command in commands;
+	};
+}

--- a/src/lib/editor/prosemirror/view/ProseMirrorView.svelte
+++ b/src/lib/editor/prosemirror/view/ProseMirrorView.svelte
@@ -9,6 +9,7 @@
 	import { schema } from './schema.js';
 	import { ActionUtilities } from './actions.js';
 	import TabState from '../../state/tab-state.svelte.js';
+	import { createShortcuts } from '../plugins/shortcut.plugin.js';
 
 	let { id, plugins = [] }: { index: number; id: string; plugins?: Plugin[] } = $props();
 
@@ -31,34 +32,35 @@
 			schema,
 			plugins: [
 				history(),
-				keymap({
-					'Ctrl-Shift-+': (state, dispatch, view) =>
+				createShortcuts({
+					subscript: (state, dispatch, view) =>
 						ActionUtilities.toggleTextMark('superscript', state, dispatch, view, 'subscript'),
-					'Ctrl-Shift-_': (state, dispatch, view) =>
+					superscript: (state, dispatch, view) =>
 						ActionUtilities.toggleTextMark('subscript', state, dispatch, view, 'superscript'),
-					'Mod-Shift-X': (state, dispatch, view) =>
+					strikethrough: (state, dispatch, view) =>
 						ActionUtilities.toggleTextMark('strikethrough', state, dispatch, view),
-					'Mod-Shift-{': (state, dispatch) =>
+					'align-left': (state, dispatch) =>
 						ActionUtilities.setTextAlignment('left', state, dispatch),
-					'Mod-Shift-}': (state, dispatch) =>
+					'align-right': (state, dispatch) =>
 						ActionUtilities.setTextAlignment('right', state, dispatch),
-					'Mod-Shift-:': (state, dispatch) =>
+					'align-center': (state, dispatch) =>
 						ActionUtilities.setTextAlignment('center', state, dispatch),
-					'Mod-Shift-"': (state, dispatch) =>
+					'align-justify': (state, dispatch) =>
 						ActionUtilities.setTextAlignment('justify', state, dispatch),
-					'Mod-z': undo,
-					'Mod-y': redo,
-					'Mod-b': (state, dispatch, view) =>
+					undo: undo,
+					redo: redo,
+					bold: (state, dispatch, view) =>
 						ActionUtilities.toggleTextMark('bold', state, dispatch, view),
-					'Mod-i': (state, dispatch, view) =>
+					italic: (state, dispatch, view) =>
 						ActionUtilities.toggleTextMark('italic', state, dispatch, view),
-					'Mod-[': (state, dispatch) => ActionUtilities.dent('dedent', state, dispatch),
-					'Mod-]': (state, dispatch) => ActionUtilities.dent('indent', state, dispatch),
-					'Mod-u': (state, dispatch, view) =>
+					dedent: (state, dispatch) => ActionUtilities.dent('dedent', state, dispatch),
+					indent: (state, dispatch) => ActionUtilities.dent('indent', state, dispatch),
+					underline: (state, dispatch, view) =>
 						ActionUtilities.toggleTextMark('underline', state, dispatch, view),
-					'Mod-j': (state, dispatch, view) =>
+					overline: (state, dispatch, view) =>
 						ActionUtilities.toggleTextMark('overline', state, dispatch, view)
 				}),
+				// TODO: Replace this
 				keymap(baseKeymap),
 				...plugins
 			]

--- a/src/lib/editor/prosemirror/view/ProseMirrorView.svelte
+++ b/src/lib/editor/prosemirror/view/ProseMirrorView.svelte
@@ -15,7 +15,6 @@
 	let el: HTMLElement;
 	let state: EditorState;
 	let view: EditorView;
-	let deregister: () => void;
 	let initialState = schema.node('doc', null, [
 		schema.node('paragraph', null, [schema.text('This is a basic paragraph with no children.')]),
 		schema.node('paragraph', null, [schema.text('This is a paragraph with more nodes.')])
@@ -70,10 +69,10 @@
 			dispatchTransaction: (transaction) => handleTransaction(view, transaction)
 		});
 
-		deregister = TabState.registerEditor(id, view);
+		const deregister = TabState.registerEditor(id, view);
 		return () => {
 			view.destroy();
-			deregister?.();
+			deregister();
 		};
 	});
 </script>

--- a/src/lib/editor/state/bar-transfer-handler.svelte.ts
+++ b/src/lib/editor/state/bar-transfer-handler.svelte.ts
@@ -1,5 +1,5 @@
 import { swap } from '$lib/utils/arrays.js';
-import { clamp } from '@/utils/numbers.js';
+import { clamp } from '$lib/utils/numbers.js';
 import type { BarItems } from './bar-items.svelte.js';
 import FloatingBarState, { type FloatingBar } from './floater-state.svelte.js';
 import HorizontalBarState, {

--- a/src/lib/editor/state/shortcuts.svelte.test.ts
+++ b/src/lib/editor/state/shortcuts.svelte.test.ts
@@ -19,33 +19,33 @@ describe('ShortcutService', () => {
 
 	describe('parse', () => {
 		it('should return a string with a standardized order from a string', () => {
-			expect(service.parse('ctrl+shift+A')).toBe('ctrl+shift+a');
-			expect(service.parse('alt+ctrl+shift+meta')).toBe('meta+alt+ctrl+shift');
+			expect(service.parse('ctrl-shift-A')).toBe('ctrl-shift-a');
+			expect(service.parse('alt-ctrl-shift-meta')).toBe('meta-alt-ctrl-shift');
 		});
 
 		it('should return a string with a standardized order from an array', () => {
-			expect(service.parse(['ctrl', 'shift', 'A'])).toBe('ctrl+shift+a');
-			expect(service.parse(['alt', 'ctrl', 'shift', 'meta'])).toBe('meta+alt+ctrl+shift');
+			expect(service.parse(['ctrl', 'shift', 'A'])).toBe('ctrl-shift-a');
+			expect(service.parse(['alt', 'ctrl', 'shift', 'meta'])).toBe('meta-alt-ctrl-shift');
 		});
 
 		it('should return a string with a standardized order from a set', () => {
-			expect(service.parse(new Set(['ctrl', 'shift', 'A']))).toBe('ctrl+shift+a');
-			expect(service.parse(new Set(['alt', 'ctrl', 'shift', 'meta']))).toBe('meta+alt+ctrl+shift');
+			expect(service.parse(new Set(['ctrl', 'shift', 'A']))).toBe('ctrl-shift-a');
+			expect(service.parse(new Set(['alt', 'ctrl', 'shift', 'meta']))).toBe('meta-alt-ctrl-shift');
 		});
 
 		it('should lowercase any uppercase letters', () => {
-			expect(service.parse('ctrl+shift+A')).toBe('ctrl+shift+a');
-			expect(service.parse(['ctrl', 'shift', 'a'])).toBe('ctrl+shift+a');
-			expect(service.parse(new Set(['ctrl', 'shift', 'a']))).toBe('ctrl+shift+a');
+			expect(service.parse('ctrl-shift-A')).toBe('ctrl-shift-a');
+			expect(service.parse(['ctrl', 'shift', 'a'])).toBe('ctrl-shift-a');
+			expect(service.parse(new Set(['ctrl', 'shift', 'a']))).toBe('ctrl-shift-a');
 		});
 	});
 
 	describe('register', () => {
 		it('should register a command with a valid shortcut', () => {
-			const result = service.register('copy', 'ctrl+C');
+			const result = service.register('copy', 'ctrl-C');
 			expect(result).toBe(true);
-			expect(service.shortcutsToCommands.get('ctrl+c')).toBe('copy');
-			expect(service.commandsToShortcuts.get('copy')).toBe('ctrl+c');
+			expect(service.shortcutsToCommands.get('ctrl-c')).toBe('copy');
+			expect(service.commandsToShortcuts.get('copy')).toBe('ctrl-c');
 		});
 
 		it('should not register a command with an invalid shortcut', () => {
@@ -63,15 +63,15 @@ describe('ShortcutService', () => {
 		});
 
 		it('should not override a preexisting command if it already exists', () => {
-			service.register('copy', 'ctrl+c');
+			service.register('copy', 'ctrl-c');
 			service.addCommand('copy');
-			expect(service.commandsToShortcuts.get('copy')).toBe('ctrl+c');
+			expect(service.commandsToShortcuts.get('copy')).toBe('ctrl-c');
 		});
 	});
 
 	describe('listen', () => {
 		it('should emit an update if a command has been registered for the shortcut', () => {
-			service.register('copy', 'ctrl+c');
+			service.register('copy', 'ctrl-c');
 			const event = new KeyboardEvent('keydown', {
 				key: 'C',
 				ctrlKey: true
@@ -104,8 +104,8 @@ describe('ShortcutService', () => {
 		});
 
 		it('should call the callback for each registered command when it occurs', () => {
-			service.register('cmd1', 'ctrl+shift+A');
-			service.register('cmd2', 'ctrl+shift+B');
+			service.register('cmd1', 'ctrl-shift-A');
+			service.register('cmd2', 'ctrl-shift-B');
 
 			emitSub = service.on({
 				cmd1: cmd1Spy,
@@ -146,22 +146,22 @@ describe('ShortcutService', () => {
 
 	describe('unset', () => {
 		it('should not unset the command if a shortcut does not exist for the command', () => {
-			service.commandsToShortcuts.set('copy', 'ctrl+c');
+			service.commandsToShortcuts.set('copy', 'ctrl-c');
 
 			const result = service.unset('copy');
 			expect(result).toBe(false);
-			expect(service.commandsToShortcuts.get('copy')).toBe('ctrl+c');
+			expect(service.commandsToShortcuts.get('copy')).toBe('ctrl-c');
 			expect(service.shortcutsToCommands.get('paste')).toBe(undefined);
 		});
 
 		it('should unset the command if it exists', () => {
-			service.register('copy', 'ctrl+c');
+			service.register('copy', 'ctrl-c');
 
 			const result = service.unset('copy');
 
 			expect(result).toBe(true);
 			expect(service.commandsToShortcuts.get('copy')).toBe('');
-			expect(service.shortcutsToCommands.get('ctrl+c')).toBe(undefined);
+			expect(service.shortcutsToCommands.get('ctrl-c')).toBe(undefined);
 		});
 
 		it("should not unset the command if it doesn't exist", () => {
@@ -169,36 +169,112 @@ describe('ShortcutService', () => {
 
 			expect(result).toBe(false);
 			expect(service.commandsToShortcuts.get('copy')).toBe(undefined);
-			expect(service.shortcutsToCommands.get('ctrl+c')).toBe(undefined);
+			expect(service.shortcutsToCommands.get('ctrl-c')).toBe(undefined);
 		});
 	});
 
 	describe('removeShortcut', () => {
 		it('should remove the shortcut from the command', () => {
-			service.register('copy', 'ctrl+c');
+			service.register('copy', 'ctrl-c');
 
-			const result = service.removeShortcut('ctrl+c');
+			const result = service.removeShortcut('ctrl-c');
 
 			expect(result).toBe(true);
 			expect(service.commandsToShortcuts.get('copy')).toBe('');
-			expect(service.shortcutsToCommands.get('ctrl+c')).toBe(undefined);
+			expect(service.shortcutsToCommands.get('ctrl-c')).toBe(undefined);
 		});
 
 		it('should not remove the command if there is not a corresponding entry in commandsToShortcuts', () => {
-			service.shortcutsToCommands.set('ctrl+c', 'copy');
-			const result = service.removeShortcut('ctrl+c');
+			service.shortcutsToCommands.set('ctrl-c', 'copy');
+			const result = service.removeShortcut('ctrl-c');
 
 			expect(result).toBe(false);
 			expect(service.commandsToShortcuts.get('copy')).toBe(undefined);
-			expect(service.shortcutsToCommands.get('ctrl+c')).toBe('copy');
+			expect(service.shortcutsToCommands.get('ctrl-c')).toBe('copy');
 		});
 
 		it("should not remove the command if it doesn't exist", () => {
-			const result = service.removeShortcut('ctrl+c');
+			const result = service.removeShortcut('ctrl-c');
 
 			expect(result).toBe(false);
 			expect(service.commandsToShortcuts.get('copy')).toBe(undefined);
-			expect(service.shortcutsToCommands.get('ctrl+c')).toBe(undefined);
+			expect(service.shortcutsToCommands.get('ctrl-c')).toBe(undefined);
+		});
+	});
+
+	describe('split', () => {
+		it('should split a string into an array of strings', () => {
+			const result = service.split('ctrl-shift-A');
+			expect(result).toEqual(['ctrl', 'shift', 'a']);
+		});
+
+		it('should properly process consecutive dashes', () => {
+			const result = service.split('---');
+			expect(result).toEqual(['-', '-']);
+		});
+	});
+
+	describe('get', () => {
+		it('should return the command name for a given shortcut', () => {
+			service.register('copy', 'ctrl-c');
+			const e = new KeyboardEvent('keydown', {
+				key: 'C',
+				ctrlKey: true
+			});
+			const result = service.get(e);
+			expect(result).toBe('copy');
+		});
+
+		it("should return null if the shortcut doesn't exist", () => {
+			const e = new KeyboardEvent('keydown', {
+				key: 'C',
+				ctrlKey: true
+			});
+			const result = service.get(e);
+			expect(result).toBe(null);
+		});
+	});
+
+	describe('process', () => {
+		it('should return the shortcut generated for a keyboard event given event', () => {
+			const e = new KeyboardEvent('keydown', {
+				key: 'C',
+				ctrlKey: true,
+				altKey: true,
+				shiftKey: true,
+				metaKey: true
+			});
+			const result = service.process(e);
+			expect(result).toBe('meta-alt-ctrl-shift-c');
+		});
+	});
+
+	describe('shortcut', () => {
+		it('should return the shortcut for a given command', () => {
+			service.register('copy', 'ctrl-c');
+			const result = service.shortcut('copy');
+			expect(result).toBe('ctrl-c');
+		});
+
+		it("should return null if the command doesn't exist", () => {
+			const result = service.shortcut('copy');
+			expect(result).toBeNull();
+		});
+	});
+
+	describe('add', () => {
+		it('should add multiple shortcuts to the service', () => {
+			const shortcuts = {
+				copy: 'ctrl-c',
+				paste: 'ctrl-v'
+			};
+
+			service.add(shortcuts);
+
+			expect(service.shortcutsToCommands.get('ctrl-c')).toBe('copy');
+			expect(service.shortcutsToCommands.get('ctrl-v')).toBe('paste');
+			expect(service.commandsToShortcuts.get('copy')).toBe('ctrl-c');
+			expect(service.commandsToShortcuts.get('paste')).toBe('ctrl-v');
 		});
 	});
 });

--- a/src/lib/editor/state/shortcuts.svelte.test.ts
+++ b/src/lib/editor/state/shortcuts.svelte.test.ts
@@ -44,28 +44,28 @@ describe('ShortcutService', () => {
 		it('should register a command with a valid shortcut', () => {
 			const result = service.register('copy', 'ctrl-C');
 			expect(result).toBe(true);
-			expect(service.shortcutsToCommands.get('ctrl-c')).toBe('copy');
-			expect(service.commandsToShortcuts.get('copy')).toBe('ctrl-c');
+			expect(service.shortcutsToCommands['ctrl-c']).toBe('copy');
+			expect(service.commandsToShortcuts['copy']).toBe('ctrl-c');
 		});
 
 		it('should not register a command with an invalid shortcut', () => {
 			const result = service.register('copy', 'C');
 			expect(result).toBe(false);
-			expect(service.shortcutsToCommands.has('C')).toBe(false);
-			expect(service.commandsToShortcuts.has('copy')).toBe(false);
+			expect(service.shortcutsToCommands['c']).toBe(undefined);
+			expect(service.commandsToShortcuts['copy']).toBe(undefined);
 		});
 	});
 
 	describe('addCommand', () => {
 		it("should add the command with an empty shortcut if it doesn't already exist", () => {
 			service.addCommand('copy');
-			expect(service.commandsToShortcuts.get('copy')).toBe('');
+			expect(service.commandsToShortcuts['copy']).toBe('');
 		});
 
 		it('should not override a preexisting command if it already exists', () => {
 			service.register('copy', 'ctrl-c');
 			service.addCommand('copy');
-			expect(service.commandsToShortcuts.get('copy')).toBe('ctrl-c');
+			expect(service.commandsToShortcuts['copy']).toBe('ctrl-c');
 		});
 	});
 
@@ -145,60 +145,41 @@ describe('ShortcutService', () => {
 	});
 
 	describe('unset', () => {
-		it('should not unset the command if a shortcut does not exist for the command', () => {
-			service.commandsToShortcuts.set('copy', 'ctrl-c');
-
-			const result = service.unset('copy');
-			expect(result).toBe(false);
-			expect(service.commandsToShortcuts.get('copy')).toBe('ctrl-c');
-			expect(service.shortcutsToCommands.get('paste')).toBe(undefined);
-		});
-
 		it('should unset the command if it exists', () => {
 			service.register('copy', 'ctrl-c');
 
 			const result = service.unset('copy');
 
 			expect(result).toBe(true);
-			expect(service.commandsToShortcuts.get('copy')).toBe('');
-			expect(service.shortcutsToCommands.get('ctrl-c')).toBe(undefined);
+			expect(service.commandsToShortcuts['copy']).toBe('');
+			expect(service.shortcutsToCommands['ctrl-c']).toBe(undefined);
 		});
 
 		it("should not unset the command if it doesn't exist", () => {
 			const result = service.unset('copy');
 
 			expect(result).toBe(false);
-			expect(service.commandsToShortcuts.get('copy')).toBe(undefined);
-			expect(service.shortcutsToCommands.get('ctrl-c')).toBe(undefined);
+			expect(service.commandsToShortcuts['copy']).toBe(undefined);
+			expect(service.shortcutsToCommands['ctrl-c']).toBe(undefined);
 		});
 	});
 
 	describe('removeShortcut', () => {
-		it('should remove the shortcut from the command', () => {
+		it('should remove the shortcut from the command', async () => {
 			service.register('copy', 'ctrl-c');
 
 			const result = service.removeShortcut('ctrl-c');
-
 			expect(result).toBe(true);
-			expect(service.commandsToShortcuts.get('copy')).toBe('');
-			expect(service.shortcutsToCommands.get('ctrl-c')).toBe(undefined);
-		});
-
-		it('should not remove the command if there is not a corresponding entry in commandsToShortcuts', () => {
-			service.shortcutsToCommands.set('ctrl-c', 'copy');
-			const result = service.removeShortcut('ctrl-c');
-
-			expect(result).toBe(false);
-			expect(service.commandsToShortcuts.get('copy')).toBe(undefined);
-			expect(service.shortcutsToCommands.get('ctrl-c')).toBe('copy');
+			expect(service.commandsToShortcuts['copy']).toBe('');
+			expect(service.shortcutsToCommands['ctrl-c']).toBe(undefined);
 		});
 
 		it("should not remove the command if it doesn't exist", () => {
 			const result = service.removeShortcut('ctrl-c');
 
 			expect(result).toBe(false);
-			expect(service.commandsToShortcuts.get('copy')).toBe(undefined);
-			expect(service.shortcutsToCommands.get('ctrl-c')).toBe(undefined);
+			expect(service.commandsToShortcuts['copy']).toBe(undefined);
+			expect(service.shortcutsToCommands['ctrl-c']).toBe(undefined);
 		});
 	});
 
@@ -271,10 +252,10 @@ describe('ShortcutService', () => {
 
 			service.add(shortcuts);
 
-			expect(service.shortcutsToCommands.get('ctrl-c')).toBe('copy');
-			expect(service.shortcutsToCommands.get('ctrl-v')).toBe('paste');
-			expect(service.commandsToShortcuts.get('copy')).toBe('ctrl-c');
-			expect(service.commandsToShortcuts.get('paste')).toBe('ctrl-v');
+			expect(service.shortcutsToCommands['ctrl-c']).toBe('copy');
+			expect(service.shortcutsToCommands['ctrl-v']).toBe('paste');
+			expect(service.commandsToShortcuts['copy']).toBe('ctrl-c');
+			expect(service.commandsToShortcuts['paste']).toBe('ctrl-v');
 		});
 	});
 });

--- a/src/lib/editor/state/shortcuts.svelte.test.ts
+++ b/src/lib/editor/state/shortcuts.svelte.test.ts
@@ -20,17 +20,17 @@ describe('ShortcutService', () => {
 	describe('parse', () => {
 		it('should return a string with a standardized order from a string', () => {
 			expect(service.parse('ctrl+shift+A')).toBe('ctrl+shift+a');
-			expect(service.parse('alt+ctrl+shift+meta')).toBe('ctrl+meta+shift+alt');
+			expect(service.parse('alt+ctrl+shift+meta')).toBe('meta+alt+ctrl+shift');
 		});
 
 		it('should return a string with a standardized order from an array', () => {
 			expect(service.parse(['ctrl', 'shift', 'A'])).toBe('ctrl+shift+a');
-			expect(service.parse(['alt', 'ctrl', 'shift', 'meta'])).toBe('ctrl+meta+shift+alt');
+			expect(service.parse(['alt', 'ctrl', 'shift', 'meta'])).toBe('meta+alt+ctrl+shift');
 		});
 
 		it('should return a string with a standardized order from a set', () => {
 			expect(service.parse(new Set(['ctrl', 'shift', 'A']))).toBe('ctrl+shift+a');
-			expect(service.parse(new Set(['alt', 'ctrl', 'shift', 'meta']))).toBe('ctrl+meta+shift+alt');
+			expect(service.parse(new Set(['alt', 'ctrl', 'shift', 'meta']))).toBe('meta+alt+ctrl+shift');
 		});
 
 		it('should lowercase any uppercase letters', () => {

--- a/src/lib/editor/state/shortcuts.svelte.test.ts
+++ b/src/lib/editor/state/shortcuts.svelte.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { ShortcutService } from './shortcuts.svelte';
+
+describe('ShortcutService', () => {
+	let service: ShortcutService;
+	const updateSpy = vi.fn();
+	let unsub: null | (() => void);
+
+	beforeEach(() => {
+		service = new ShortcutService();
+		unsub = service.subscribe(updateSpy);
+	});
+
+	afterEach(() => {
+		unsub?.();
+		updateSpy.mockClear();
+	});
+
+	describe('parse', () => {
+		it('should return a string with a standardized order from a string', () => {
+			expect(service.parse('ctrl+shift+A')).toBe('ctrl+shift+a');
+			expect(service.parse('alt+ctrl+shift+meta')).toBe('ctrl+meta+shift+alt');
+		});
+
+		it('should return a string with a standardized order from an array', () => {
+			expect(service.parse(['ctrl', 'shift', 'A'])).toBe('ctrl+shift+a');
+			expect(service.parse(['alt', 'ctrl', 'shift', 'meta'])).toBe('ctrl+meta+shift+alt');
+		});
+
+		it('should return a string with a standardized order from a set', () => {
+			expect(service.parse(new Set(['ctrl', 'shift', 'A']))).toBe('ctrl+shift+a');
+			expect(service.parse(new Set(['alt', 'ctrl', 'shift', 'meta']))).toBe('ctrl+meta+shift+alt');
+		});
+
+		it('should lowercase any uppercase letters', () => {
+			expect(service.parse('ctrl+shift+A')).toBe('ctrl+shift+a');
+			expect(service.parse(['ctrl', 'shift', 'a'])).toBe('ctrl+shift+a');
+			expect(service.parse(new Set(['ctrl', 'shift', 'a']))).toBe('ctrl+shift+a');
+		});
+	});
+
+	describe('register', () => {
+		it('should register a command with a valid shortcut', () => {
+			const result = service.register('copy', 'ctrl+C');
+			expect(result).toBe(true);
+			expect(service.shortcutsToCommands.get('ctrl+c')).toBe('copy');
+		});
+
+		it('should not register a command with an invalid shortcut', () => {
+			const result = service.register('copy', 'C');
+			expect(result).toBe(false);
+			expect(service.shortcutsToCommands.has('C')).toBe(false);
+		});
+	});
+
+	describe('listen', () => {
+		it('should emit an update if a command has been registered for the shortcut', () => {
+			service.register('copy', 'ctrl+c');
+			const event = new KeyboardEvent('keydown', {
+				key: 'C',
+				ctrlKey: true
+			});
+
+			service.listen(event);
+			expect(updateSpy).toHaveBeenCalledWith('copy');
+		});
+
+		it('should not emit an update if the command has not been registered', () => {
+			const event = new KeyboardEvent('keydown', {
+				key: 'C',
+				ctrlKey: true
+			});
+
+			service.listen(event);
+			expect(updateSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('emit', () => {
+		let emitSub: (() => void) | null = null;
+		const cmd1Spy = vi.fn();
+		const cmd2Spy = vi.fn();
+		afterEach(() => {
+			cmd1Spy.mockClear();
+			cmd2Spy.mockClear();
+			emitSub?.();
+			emitSub = null;
+		});
+
+		it('should call the callback for each registered command when it occurs', () => {
+			service.register('cmd1', 'ctrl+shift+A');
+			service.register('cmd2', 'ctrl+shift+B');
+
+			emitSub = service.on({
+				cmd1: cmd1Spy,
+				cmd2: cmd2Spy
+			});
+
+			const event = new KeyboardEvent('keydown', {
+				key: 'A',
+				ctrlKey: true,
+				shiftKey: true
+			});
+			service.listen(event);
+
+			expect(cmd1Spy).toHaveBeenCalledOnce();
+			expect(cmd2Spy).not.toHaveBeenCalled();
+
+			const event2 = new KeyboardEvent('keydown', {
+				key: 'B',
+				ctrlKey: true,
+				shiftKey: true
+			});
+			service.listen(event2);
+
+			expect(cmd1Spy).toHaveBeenCalledOnce();
+			expect(cmd2Spy).toHaveBeenCalledOnce();
+		});
+	});
+});

--- a/src/lib/editor/state/shortcuts.svelte.ts
+++ b/src/lib/editor/state/shortcuts.svelte.ts
@@ -46,14 +46,14 @@ export class ShortcutService extends Observable<string> {
 		const output: string[] = [];
 		for (const char of str) {
 			if (char === this.SEPARATOR && currentShortcutPart) {
-				output.push(currentShortcutPart);
+				output.push(currentShortcutPart.toLocaleLowerCase());
 				currentShortcutPart = '';
 			} else {
 				currentShortcutPart += char;
 			}
 		}
 
-		output.push(currentShortcutPart);
+		output.push(currentShortcutPart.toLocaleLowerCase());
 		return output;
 	}
 
@@ -174,7 +174,6 @@ export class ShortcutService extends Observable<string> {
 
 	get(e: KeyboardEvent): string | null {
 		const shortcut = this.process(e);
-		console.log(shortcut);
 		return this.shortcutsToCommands.get(shortcut) || null;
 	}
 

--- a/src/lib/editor/state/shortcuts.svelte.ts
+++ b/src/lib/editor/state/shortcuts.svelte.ts
@@ -8,31 +8,29 @@ export class ShortcutService extends Observable<string> {
 
 	#standardize(cmd: string[]): string {
 		const output: string[] = [];
-		const cmdKeyIndex = cmd.findIndex((key) => key.toLowerCase() === 'ctrl');
-		if (cmdKeyIndex !== -1) {
-			cmd.splice(cmdKeyIndex, 1);
-			output.push('ctrl');
-		}
-
 		const metaKeyIndex = cmd.findIndex((key) => key.toLowerCase() === 'meta');
 		if (metaKeyIndex !== -1) {
 			output.push('meta');
-			cmd.splice(metaKeyIndex, 1);
-		}
-
-		const shiftKeyIndex = cmd.findIndex((key) => key.toLowerCase() === 'shift');
-		if (shiftKeyIndex !== -1) {
-			output.push('shift');
-			cmd.splice(shiftKeyIndex, 1);
 		}
 
 		const altKeyIndex = cmd.findIndex((key) => key.toLowerCase() === 'alt');
 		if (altKeyIndex !== -1) {
 			output.push('alt');
-			cmd.splice(altKeyIndex, 1);
 		}
 
-		const finalKey = cmd.at(0);
+		const cmdKeyIndex = cmd.findIndex((key) => key.toLowerCase() === 'ctrl');
+		if (cmdKeyIndex !== -1) {
+			output.push('ctrl');
+		}
+
+		const shiftKeyIndex = cmd.findIndex((key) => key.toLowerCase() === 'shift');
+		if (shiftKeyIndex !== -1) {
+			output.push('shift');
+		}
+
+		const finalKey = cmd.find(
+			(key) => key !== 'ctrl' && key !== 'meta' && key !== 'alt' && key !== 'shift'
+		);
 		if (finalKey) {
 			output.push(finalKey.toLocaleLowerCase());
 		}
@@ -117,20 +115,20 @@ export class ShortcutService extends Observable<string> {
 
 	listen(e: KeyboardEvent) {
 		const shortcut = [e.key];
-		if (e.altKey) {
-			shortcut.push('alt');
-		}
-
 		if (e.shiftKey) {
 			shortcut.push('shift');
 		}
 
-		if (e.metaKey) {
-			shortcut.push('meta');
-		}
-
 		if (e.ctrlKey) {
 			shortcut.push('ctrl');
+		}
+
+		if (e.altKey) {
+			shortcut.push('alt');
+		}
+
+		if (e.metaKey) {
+			shortcut.push('meta');
 		}
 
 		const key = this.#standardize(shortcut);
@@ -146,6 +144,13 @@ export class ShortcutService extends Observable<string> {
 
 	on(shortcuts: Record<string, () => void>): () => void {
 		return this.subscribe((val) => shortcuts[val]?.());
+	}
+
+	add(shortcuts: Record<string, string>) {
+		for (const [key, value] of Object.entries(shortcuts)) {
+			this.register(key, value);
+		}
+		return this;
 	}
 }
 

--- a/src/lib/editor/state/shortcuts.svelte.ts
+++ b/src/lib/editor/state/shortcuts.svelte.ts
@@ -20,8 +20,9 @@ export class ShortcutService extends Observable<string> {
 	});
 	commandsToDisplayedShortcuts = $derived.by(() => {
 		const displayShortcuts: Record<string, string> = {};
+		const useMacShortcuts = isMac();
 		for (const [command, shortcut] of Object.entries(this.commandsToShortcuts)) {
-			displayShortcuts[command] = this.display(shortcut, isMac());
+			displayShortcuts[command] = this.display(shortcut, useMacShortcuts);
 		}
 		return displayShortcuts;
 	});
@@ -60,9 +61,12 @@ export class ShortcutService extends Observable<string> {
 		escape: 'escape'
 	};
 
+	MAC_SEPARATOR = '';
+	WINDOWS_SEPARATOR = '+';
+
 	display(shortcut: string, isMac: boolean): string {
 		const specialKeys = isMac ? this.MAC_SPECIAL_KEYS : this.WINDOWS_SPECIAL_KEYS;
-		const separator = isMac ? '' : '+';
+		const separator = isMac ? this.MAC_SEPARATOR : this.WINDOWS_SEPARATOR;
 		return this.split(shortcut)
 			.reduce<string[]>((acc, next) => {
 				const k = next in specialKeys ? specialKeys[next as keyof typeof specialKeys] : next;
@@ -151,18 +155,6 @@ export class ShortcutService extends Observable<string> {
 
 		this.commandsToShortcuts[name] = '';
 		return true;
-	}
-
-	removeShortcut(shortcut: Set<string> | string[] | string) {
-		const key = this.parse(shortcut);
-		const names = this.shortcutsToCommands[key];
-		for (const name of names) {
-			if (name in this.commandsToShortcuts) {
-				this.commandsToShortcuts[name] = '';
-			}
-		}
-
-		return this;
 	}
 
 	register(name: string, shortcut: Set<string> | string[] | string): boolean {

--- a/src/lib/editor/state/shortcuts.svelte.ts
+++ b/src/lib/editor/state/shortcuts.svelte.ts
@@ -1,0 +1,88 @@
+import { SvelteMap } from 'svelte/reactivity';
+
+import { Observable } from '$lib/utils/observable';
+
+export class ShortcutService extends Observable<string> {
+	commands = new SvelteMap<string, string>();
+
+	#homogenize(cmd: string[]): string {
+		const output: string[] = [];
+		const cmdKeyIndex = cmd.findIndex((key) => key.toLowerCase() === 'ctrl');
+		if (cmdKeyIndex !== -1) {
+			cmd.splice(cmdKeyIndex, 1);
+			output.push('ctrl');
+		}
+
+		const metaKeyIndex = cmd.findIndex((key) => key.toLowerCase() === 'meta');
+		if (metaKeyIndex !== -1) {
+			output.push('meta');
+			cmd.splice(metaKeyIndex, 1);
+		}
+
+		const shiftKeyIndex = cmd.findIndex((key) => key.toLowerCase() === 'shift');
+		if (shiftKeyIndex !== -1) {
+			output.push('shift');
+			cmd.splice(shiftKeyIndex, 1);
+		}
+
+		const altKeyIndex = cmd.findIndex((key) => key.toLowerCase() === 'alt');
+		if (altKeyIndex !== -1) {
+			output.push('alt');
+			cmd.splice(altKeyIndex, 1);
+		}
+
+		output.push(cmd[0].toLocaleLowerCase());
+		return output.join('+');
+	}
+
+	parse(cmd: Set<string> | string[] | string): string {
+		if (typeof cmd === 'string') {
+			const arr = cmd.split('+');
+			return this.#homogenize(arr);
+		} else if (Array.isArray(cmd)) {
+			return this.#homogenize(cmd);
+		} else {
+			const arr = [...cmd];
+			return this.#homogenize(arr);
+		}
+	}
+
+	register(name: string, cmd: Set<string> | string[] | string) {
+		const key = this.parse(cmd);
+		this.commands.set(key, name);
+		return this;
+	}
+
+	listen(e: KeyboardEvent) {
+		const cmd = [e.key];
+		if (e.altKey) {
+			cmd.push('alt');
+		}
+
+		if (e.shiftKey) {
+			cmd.push('shift');
+		}
+
+		if (e.metaKey) {
+			cmd.push('meta');
+		}
+
+		if (e.ctrlKey) {
+			cmd.push('ctrl');
+		}
+
+		const key = this.#homogenize(cmd);
+		const emitted = this.commands.get(key);
+		if (emitted) {
+			this.update(emitted);
+		}
+	}
+
+	on(cmds: Record<string, () => void>): () => void {
+		const unsub = this.subscribe((val) => cmds[val]?.());
+		return unsub;
+	}
+}
+
+const Shortcuts = new ShortcutService();
+export default Shortcuts;

--- a/src/lib/editor/state/shortcuts.svelte.ts
+++ b/src/lib/editor/state/shortcuts.svelte.ts
@@ -1,5 +1,6 @@
 import { Observable } from '$lib/utils/observable';
 import { isMac } from '$lib/utils/misc';
+import { capitalize } from '$lib/utils/strings';
 
 export class ShortcutService extends Observable<string> {
 	commandsToShortcuts = $state<Record<string, string>>({});
@@ -21,8 +22,46 @@ export class ShortcutService extends Observable<string> {
 	});
 	SEPARATOR = '-';
 
+	WINDOWS_SPECIAL_KEYS = {
+		arrowdown: 'DownArrow',
+		arrowup: 'UpArrow',
+		arrowleft: 'LeftArrow',
+		arrowright: 'RightArrow',
+		ctrl: 'Ctrl',
+		shift: 'Shift',
+		meta: 'Win',
+		alt: 'Alt',
+		enter: 'enter',
+		backspace: 'backspace',
+		delete: 'delete',
+		escape: 'esc'
+	};
+
+	MAC_SPECIAL_KEYS = {
+		arrowdown: '↓',
+		arrowup: '↑',
+		arrowleft: '←',
+		arrowright: '→',
+		ctrl: '⌃',
+		meta: '⌘',
+		alt: '⌥',
+		shift: '⇧',
+		enter: '↩',
+		backspace: 'delete',
+		delete: 'fn delete',
+		escape: 'escape'
+	};
+
 	display(shortcut: string, isMac: boolean): string {
-		return (shortcut && isMac && 'a') || '';
+		const specialKeys = isMac ? this.MAC_SPECIAL_KEYS : this.WINDOWS_SPECIAL_KEYS;
+		const separator = isMac ? '' : '+';
+		return this.split(shortcut)
+			.reduce<string[]>((acc, next) => {
+				const k = next in specialKeys ? specialKeys[next as keyof typeof specialKeys] : next;
+				const capitalized = k.split(' ').map(capitalize);
+				return acc.concat(capitalized);
+			}, [])
+			.join(separator);
 	}
 
 	#standardize(cmd: string[]): string {

--- a/src/lib/utils/misc.ts
+++ b/src/lib/utils/misc.ts
@@ -1,0 +1,6 @@
+export function isMac(): boolean {
+	if (!window || !window.navigator) {
+		return false;
+	}
+	return navigator.userAgent.toLocaleLowerCase().includes('mac');
+}

--- a/src/lib/utils/observable.ts
+++ b/src/lib/utils/observable.ts
@@ -1,12 +1,23 @@
+/**
+ * Base class for making a value and its change into an observable. It does not store the current value.
+ */
 export class Observable<Data> {
 	#subscribers: Map<string, (data: Data) => void | Promise<void>> = new Map();
 
+	/**
+	 * Subscribe to this observable for every this it's called. Returns a function to unsubscribe.
+	 */
 	subscribe(callback: (data: Data) => void | Promise<void>): () => void {
 		const id = crypto.randomUUID();
 		this.#subscribers.set(id, callback);
 		return () => this.#subscribers.delete(id);
 	}
 
+	/**
+	 * Send a new value to all subscribers.
+	 *
+	 * NOTE: It will not call the callback on subscription, only on future updates.
+	 */
 	update(data: Data) {
 		for (const subscriber of this.#subscribers.values()) {
 			subscriber(data);
@@ -14,6 +25,10 @@ export class Observable<Data> {
 	}
 }
 
+/**
+ * Similar to an observable, but it requires an initial value. Unlike the base observable,
+ * it will immediately call the callback with the current value.
+ */
 export class RequiredObservable<Data> extends Observable<Data> {
 	protected _data: Data;
 
@@ -26,11 +41,17 @@ export class RequiredObservable<Data> extends Observable<Data> {
 		return this._data;
 	}
 
+	/**
+	 * Sets the data and calls all subscribers with the new value.
+	 */
 	set data(data: Data) {
 		this._data = data;
 		this.update(data);
 	}
 
+	/**
+	 * Similar to a normal observable but will immediately call the callback with the current value.
+	 */
 	subscribe(callback: (data: Data) => void | Promise<void>): () => void {
 		callback(this._data);
 		return super.subscribe(callback);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,10 +4,12 @@
 
 	import { i18n } from '$lib/i18n';
 	import { ParaglideJS } from '@inlang/paraglide-sveltekit';
+	import Shortcuts from '@/editor/state/shortcuts.svelte';
 
 	let { children } = $props();
 </script>
 
+<svelte:window onkeydown={(e) => Shortcuts.listen(e)} onkeyup={(e) => Shortcuts.listen(e)} />
 <ParaglideJS {i18n}>
 	{@render children()}
 </ParaglideJS>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,10 @@
 	import Editor from '$lib/editor/Editor.svelte';
 	import { MenuItem } from '$lib/editor/prosemirror/menu/basic/menu.js';
 	import Registry from '$lib/editor/state/bar-item-registry.svelte';
+	import Shortcuts from '$lib/editor/state/shortcuts.svelte';
+	import { builtInShortcuts } from './shortcuts';
+
+	Shortcuts.add(builtInShortcuts);
 	Registry.register(MenuItem.item, MenuItem.id);
 </script>
 

--- a/src/routes/shortcuts.ts
+++ b/src/routes/shortcuts.ts
@@ -15,6 +15,15 @@ const builtInShortcuts = {
 	underline: 'meta-u',
 	overline: 'meta-j',
 	indent: 'meta-]',
-	dedent: 'meta-['
+	dedent: 'meta-[',
+	'move-bar-inline-start': 'meta-shift-e',
+	'move-bar-inline-end': 'meta-shift-r',
+	'move-bar-block-start': 'meta-shift-t',
+	'move-bar-block-end': 'meta-shift-y',
+	'move-bar-floating': 'meta-shift-u',
+	'move-bar-up': 'meta-shift-arrowup',
+	'move-bar-down': 'meta-shift-arrowdown',
+	'move-bar-left': 'meta-shift-arrowleft',
+	'move-bar-right': 'meta-shift-arrowright'
 } as const;
 export { builtInShortcuts };

--- a/src/routes/shortcuts.ts
+++ b/src/routes/shortcuts.ts
@@ -1,3 +1,5 @@
+// TODO: These will be saved into a system-wide config file
+// that will be editable when the user has initially set up the system.
 const builtInShortcuts = {
 	subscript: 'ctrl-shift-+',
 	superscript: 'ctrl-shift-_',

--- a/src/routes/shortcuts.ts
+++ b/src/routes/shortcuts.ts
@@ -1,4 +1,29 @@
 const builtInShortcuts: Record<string, string> = {
-	subscript: 'Ctrl-Shift-+'
+	subscript: 'Ctrl+Shift++'
+   'Ctrl+Shift+-'
+					'Ctrl-Shift-_': (state, dispatch, view) =>
+						ActionUtilities.toggleTextMark('subscript', state, dispatch, view, 'superscript'),
+					'Mod-Shift-X': (state, dispatch, view) =>
+						ActionUtilities.toggleTextMark('strikethrough', state, dispatch, view),
+					'Mod-Shift-{': (state, dispatch) =>
+						ActionUtilities.setTextAlignment('left', state, dispatch),
+					'Mod-Shift-}': (state, dispatch) =>
+						ActionUtilities.setTextAlignment('right', state, dispatch),
+					'Mod-Shift-:': (state, dispatch) =>
+						ActionUtilities.setTextAlignment('center', state, dispatch),
+					'Mod-Shift-"': (state, dispatch) =>
+						ActionUtilities.setTextAlignment('justify', state, dispatch),
+					'Mod-z': undo,
+					'Mod-y': redo,
+					'Mod-b': (state, dispatch, view) =>
+						ActionUtilities.toggleTextMark('bold', state, dispatch, view),
+					'Mod-i': (state, dispatch, view) =>
+						ActionUtilities.toggleTextMark('italic', state, dispatch, view),
+					'Mod-[': (state, dispatch) => ActionUtilities.dent('dedent', state, dispatch),
+					'Mod-]': (state, dispatch) => ActionUtilities.dent('indent', state, dispatch),
+					'Mod-u': (state, dispatch, view) =>
+						ActionUtilities.toggleTextMark('underline', state, dispatch, view),
+					'Mod-j': (state, dispatch, view) =>
+						ActionUtilities.toggleTextMark('overline', state, dispatch, view)
 };
 export { builtInShortcuts };

--- a/src/routes/shortcuts.ts
+++ b/src/routes/shortcuts.ts
@@ -1,29 +1,18 @@
-const builtInShortcuts: Record<string, string> = {
-	subscript: 'Ctrl+Shift++'
-   'Ctrl+Shift+-'
-					'Ctrl-Shift-_': (state, dispatch, view) =>
-						ActionUtilities.toggleTextMark('subscript', state, dispatch, view, 'superscript'),
-					'Mod-Shift-X': (state, dispatch, view) =>
-						ActionUtilities.toggleTextMark('strikethrough', state, dispatch, view),
-					'Mod-Shift-{': (state, dispatch) =>
-						ActionUtilities.setTextAlignment('left', state, dispatch),
-					'Mod-Shift-}': (state, dispatch) =>
-						ActionUtilities.setTextAlignment('right', state, dispatch),
-					'Mod-Shift-:': (state, dispatch) =>
-						ActionUtilities.setTextAlignment('center', state, dispatch),
-					'Mod-Shift-"': (state, dispatch) =>
-						ActionUtilities.setTextAlignment('justify', state, dispatch),
-					'Mod-z': undo,
-					'Mod-y': redo,
-					'Mod-b': (state, dispatch, view) =>
-						ActionUtilities.toggleTextMark('bold', state, dispatch, view),
-					'Mod-i': (state, dispatch, view) =>
-						ActionUtilities.toggleTextMark('italic', state, dispatch, view),
-					'Mod-[': (state, dispatch) => ActionUtilities.dent('dedent', state, dispatch),
-					'Mod-]': (state, dispatch) => ActionUtilities.dent('indent', state, dispatch),
-					'Mod-u': (state, dispatch, view) =>
-						ActionUtilities.toggleTextMark('underline', state, dispatch, view),
-					'Mod-j': (state, dispatch, view) =>
-						ActionUtilities.toggleTextMark('overline', state, dispatch, view)
-};
+const builtInShortcuts = {
+	subscript: 'ctrl-shift-+',
+	superscript: 'ctrl-shift-_',
+	strikethrough: 'meta-shift-x',
+	'align-left': 'meta-shift-[',
+	'align-right': 'meta-shift-]',
+	'align-center': 'meta-shift-;',
+	'align-justify': "meta-shift-'",
+	undo: 'meta-z',
+	redo: 'meta-y',
+	bold: 'meta-b',
+	italic: 'meta-i',
+	underline: 'meta-u',
+	overline: 'meta-j',
+	indent: 'meta-]',
+	dedent: 'meta-['
+} as const;
 export { builtInShortcuts };

--- a/src/routes/shortcuts.ts
+++ b/src/routes/shortcuts.ts
@@ -1,0 +1,4 @@
+const builtInShortcuts: Record<string, string> = {
+	subscript: 'Ctrl-Shift-+'
+};
+export { builtInShortcuts };


### PR DESCRIPTION
Closes #22

## Changes
* Add shortcut service that is an observable for keyboard events and has a bunch of handy dandy state
* Write our own keyboard shortcut plugin that uses said service
* Add shortcuts to the menu
* Add clarifying comments to observables